### PR TITLE
fix(extract): undefined filename checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function instantiateMbox(outputDir, dryRun, subDirs) {
 
 		mailParser.on("data", function (data) {
 			var myFile, fileToWrite;
-			if (data.type === "attachment") {
+			if (data.type === "attachment" && data.filename) {
 				fileToWrite = path.join(currentDir, data.filename);
 				console.log(data.filename);
 				if (!dryRun) {


### PR DESCRIPTION
Adds additional checking if the `filename` is defined.

```
path.js:28
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:28:11)
    at Object.join (path.js:1232:7)
    at MailParser.<anonymous> (/usr/lib/node_modules/mboxtract/index.js:69:24)
    at emitOne (events.js:115:13)
    at MailParser.emit (events.js:210:7)
    at addChunk (_stream_readable.js:252:12)
    at readableAddChunk (_stream_readable.js:239:11)
    at MailParser.Readable.push (_stream_readable.js:197:10)
    at MailParser.Transform.push (_stream_transform.js:151:32)
    at MailParser.processChunk (/usr/lib/node_modules/mboxtract/node_modules/mailparser/lib/mail-parser.js:603:30)
```