### PR TITLE
Fix filepaths containing forward slashes on non-Windows platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,12 @@ function instantiateMbox(outputDir, dryRun, subDirs) {
 		mailParser.on("data", function (data) {
 			var myFile, fileToWrite;
 			if (data.type === "attachment" && data.filename) {
-				fileToWrite = path.join(currentDir, data.filename);
-				console.log(data.filename);
+				var filename = data.filename;
+				if (process.platform != "win32") {
+					filename = filename.replace(/\//g, "-");
+				}
+				fileToWrite = path.join(currentDir, filename);
+				console.log(filename);
 				if (!dryRun) {
 					myFile = fs.createWriteStream(fileToWrite);
 					data.content.pipe(myFile);


### PR DESCRIPTION
This is a small fix for filepaths with forward slashes on non-Windows platforms causing `Error: ENOENT: no such file or directory`.

Tested on Manjaro Linux, node v16.16.0.

Thank you very much for this nifty project!