### PR TITLE
fix: some attachments have invalid filenames, and duplicated attachment names overwrite eachother

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,11 +67,10 @@ function instantiateMbox(outputDir, dryRun, subDirs) {
 			var myFile, fileToWrite;
 			if (data.type === "attachment" && data.filename) {
 				var filename = data.filename;
-				if (process.platform != "win32") {
-					filename = filename.replace(/\//g, "-");
-				}
-				fileToWrite = path.join(currentDir, filename);
-				console.log(filename);
+				var sanitized = filename.replace(/[^\w\-. ]/g, "_");
+
+				fileToWrite = getAvailableFilename(path.join(currentDir, sanitized));
+				console.log(sanitized);
 				if (!dryRun) {
 					myFile = fs.createWriteStream(fileToWrite);
 					data.content.pipe(myFile);
@@ -83,6 +82,22 @@ function instantiateMbox(outputDir, dryRun, subDirs) {
 		mailParser.end();
 	});
 	return mbox;
+}
+
+function getAvailableFilename(filepath) {
+	const dir = path.dirname(filepath);
+	const ext = path.extname(filepath);
+	const base = path.basename(filepath, ext);
+  
+	let candidate = filepath;
+	let counter = 1;
+  
+	while (fs.existsSync(candidate)) {
+	  candidate = path.join(dir, `${base}_${counter}${ext}`);
+	  counter++;
+	}
+  
+	return candidate;
 }
 
 function pad(num) {


### PR DESCRIPTION
Closes #2 

Per title. There were two bugs here:
- When attachments have invalid filenames they can not be written to disk and this stops the whole process
  - When there is a `\` or `/` char in the filename, it causes #2 since this is treated as a "folder" but we have not created the folder.
- When attachments from different emails have the same filename, they get overwritten in the output folder.
  - Now we check if the filename already exists, and if it does we write it to a new file with `_1`, `_2`, etc appended to the filename.